### PR TITLE
Improve Room Validity Checking Functions

### DIFF
--- a/Core/Constants.cs
+++ b/Core/Constants.cs
@@ -11,21 +11,24 @@
     public struct HeaderData
     {
         public int MapHeaderBase;
+        // Name on this is gonna have to change sometime
+        public int AreaMetadataBase;
 
-        public HeaderData(int map)
+        public HeaderData(int map, int area)
         {
             this.MapHeaderBase = map;
+            this.AreaMetadataBase = area;
         }
     }
 
     public class Header
     {
         // Will fill out when relevant, only need EU for now
-        private HeaderData[] headerTable = new HeaderData[]
-        {   //             MAP     ,
-            new HeaderData(0x11D95C),
-            new HeaderData(0), 
-            new HeaderData(0x11E214)
+        private readonly HeaderData[] headerTable = new HeaderData[]
+        {   //             MAP     , AREA
+            new HeaderData(0x11D95C, 0x0D4828),
+            new HeaderData(0, 0), 
+            new HeaderData(0x11E214, 0)
         };
 
         public HeaderData GetHeaderAddresses(RegionVersion region)

--- a/Core/MapManager.cs
+++ b/Core/MapManager.cs
@@ -58,7 +58,7 @@ namespace MinishMaker.Core
                 {
                     if (IsValidRoom(areaNum, roomNum))
                     {
-                        if (IsRoomStable(areaNum, roomNum))
+                        if (IsStableRoom(areaNum, roomNum))
                         {
                             area.Add(new Room(roomNum));
                         }
@@ -97,7 +97,7 @@ namespace MinishMaker.Core
             return roomheader != 0xFFFF;
         }
 
-        private bool IsRoomStable(int area, int room)
+        private bool IsStableRoom(int area, int room)
         {
 
             int areasearchaddr = ROM.Instance.headers.AreaMetadataBase + (area << 2);

--- a/Core/MapManager.cs
+++ b/Core/MapManager.cs
@@ -53,18 +53,18 @@ namespace MinishMaker.Core
             for (int areaNum = 0; areaNum < 0x90; areaNum++)
             {
                 Area area = new Area(areaNum);
-                int roomNum = 0;
-                do
+
+                for (int roomNum = 0; roomNum < 0x40; roomNum++)
                 {
                     if (IsValidRoom(areaNum, roomNum))
                     {
-                        // Setup new room data
-                        area.Add(new Room());
-                        roomNum++;
+                        if (IsRoomStable(areaNum, roomNum))
+                        {
+                            area.Add(new Room(roomNum));
+                        }
                     }
-
                     else break;
-                } while (true);
+                }
 
                 // At least one room in area, so add to list.
                 if (area.Count() > 0)
@@ -85,12 +85,8 @@ namespace MinishMaker.Core
             // Not a valid data address as doesn't point to anywhere
             if (addr == 0) return false;
 
-            
-            int roomaddr = ROM.Instance.reader.ReadUInt16(addr + room * 0x0A);
-            
-            if (roomaddr == 0xFFFF) return false;
-            ROM.Instance.reader.ReadUInt32();
-            ROM.Instance.reader.ReadUInt16();
+            int roomaddr = addr + room * 0x0A;
+            int roomheader = ROM.Instance.reader.ReadUInt16(roomaddr);
 
             // Debug prints
             Console.WriteLine("Area: {0} Room: {1}", StringUtil.AsStringHex2(area), StringUtil.AsStringHex2(room));
@@ -98,12 +94,23 @@ namespace MinishMaker.Core
             Console.WriteLine("Room header: {0}", StringUtil.AsStringGBAAddress(addr + room * 0x0A));
             Console.WriteLine("Header Value: {0}", StringUtil.AsStringHex4(roomaddr));
 
-            int finalval = ROM.Instance.reader.ReadUInt16();
-            Console.WriteLine("Final checked Value: {0}", StringUtil.AsStringHex4(finalval));
-            Console.WriteLine("Comparison check: {0}", StringUtil.AsStringHex4(finalval & 0x8000));
+            return roomheader != 0xFFFF;
+        }
 
-            // BUG This final check isn't perfect. Will think some rooms are valid and others not, particularly when the game would usually softlock. See room doc for more details.
-            return (finalval & 0x8000) == 0;
+        private bool IsRoomStable(int area, int room)
+        {
+
+            int areasearchaddr = ROM.Instance.headers.AreaMetadataBase + (area << 2);
+            int areaaddr = ROM.Instance.reader.ReadAddr(areasearchaddr);
+
+            // This used to happen sometimes for some reason, so I left the check in
+            if (areaaddr == 0x000000) return false;
+
+            int roomsearchaddr = areaaddr + (room << 2);
+            int roomaddr = ROM.Instance.reader.ReadAddr(roomsearchaddr);
+
+            // If the room is considered valid and has metadata, it's probably stable. BUG: Fortress of Winds 05 and 06, as well as Area 67 Room 04 are false positives
+            return roomaddr != 0x000000;
         }
     }
 }

--- a/Core/Room.cs
+++ b/Core/Room.cs
@@ -2,6 +2,11 @@
 {
     public class Room
     {
-        
+        public int Index { get; private set; }
+
+        public Room(int index)
+        {
+            Index = index;
+        }
     }
 }

--- a/UI/MainWindow.cs
+++ b/UI/MainWindow.cs
@@ -98,9 +98,9 @@ namespace MinishMaker.UI
             {
                 roomTreeView.Nodes.Add("Area " + StringUtil.AsStringHex2(area.Index));
                 
-                for(int room = 0; room < area.Rooms().Count(); room++)
+                foreach(Room room in area.Rooms())
                 {
-                    roomTreeView.Nodes[subsection].Nodes.Add("Room " + StringUtil.AsStringHex2(room));
+                    roomTreeView.Nodes[subsection].Nodes.Add("Room " + StringUtil.AsStringHex2(room.Index));
                 }
                 subsection++;
             }


### PR DESCRIPTION
I changed the room validity checker to be more similar to the in-game data load checker. It doesn't quite match the room doc (mainly false positives, with a few false negatives in unused rooms). This fixes most of #3, but does not fully close it.