### PR TITLE
Added a notification when trying to load wrong version

### DIFF
--- a/UI/MainWindow.cs
+++ b/UI/MainWindow.cs
@@ -141,7 +141,13 @@ namespace MinishMaker.UI
 				throw;
 			}
 
-			if( ROM.Instance.version.Equals( RegionVersion.None ) )
+			if (ROM.Instance.version.Equals(RegionVersion.EU) == false) {
+				MessageBox.Show("Invalid TMC ROM. Only the EU version is supported at this time.", "Wrong Version", MessageBoxButtons.OK);
+				statusText.Text = "Incorrect ROM version.";
+				return;
+			}
+
+			if ( ROM.Instance.version.Equals( RegionVersion.None ) )
 			{
 				MessageBox.Show( "Invalid TMC ROM. Please Open a valid ROM.", "Incorrect ROM", MessageBoxButtons.OK );
 				statusText.Text = "Unable to determine ROM.";


### PR DESCRIPTION
Just for better ease of use, I added a warning for loading a US or JP version of the ROM. It's a quick fix but I think it'd be good enough for now.